### PR TITLE
Fixed Closing Head Tag Missing Issue

### DIFF
--- a/src/CssToInlineStyles.php
+++ b/src/CssToInlineStyles.php
@@ -304,7 +304,7 @@ class CssToInlineStyles
         &&
         $this->css_media_queries
     ) {
-      $html = str_ireplace('</head>', '<style type="text/css">' . "\n" . $this->css_media_queries . "\n" . '</styles>', $html);
+      $html = str_ireplace('</head>', '<style type="text/css">' . "\n" . $this->css_media_queries . "\n" . '</styles></head>', $html);
     }
 
     return $html;


### PR DESCRIPTION
Fixed Closing Head Tag Missing Issue. It wasn't showing when using Media Query in CSS.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/voku/csstoinlinestyles/26)
<!-- Reviewable:end -->
